### PR TITLE
Use double quotes for linter

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -82,7 +82,7 @@
     "prefer-const": true,
     "quotemark": [
       true,
-      "single"
+      "double"
     ],
     "radix": true,
     "semicolon": [


### PR DESCRIPTION
It seems to be the convention of this library to use double quotes. Should this be the standard that tslint operates on?