### PR TITLE
Fix message not showing for deeply nested control

### DIFF
--- a/projects/ng-bootstrap-form-validation/src/lib/Components/form-group/form-group.component.ts
+++ b/projects/ng-bootstrap-form-validation/src/lib/Components/form-group/form-group.component.ts
@@ -23,7 +23,7 @@ import { ErrorMessage } from "../../Models/error-message";
   `
 })
 export class FormGroupComponent implements OnInit, AfterContentInit {
-  @ContentChildren(FormControlName)
+  @ContentChildren(FormControlName, {descendants: true})
   FormControlNames: QueryList<FormControlName>;
 
   @Input()


### PR DESCRIPTION
Fix showing the error message not showing in case form-control is deeply nested like this
<div class="form-group"><div><input class="form-control"/></div></div>

this happened after upgrading to Angular 9, disabling Ivey Compiler on the Application level somehow solves the problem 